### PR TITLE
Revert "change executable name to crc-background-launcher.exe"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ VERSION := 0.0.0.1
 .PHONY: win32-background-launcher
 win32-background-launcher: $(TOOLS_BINDIR)/go-winres
 	GOOS=windows ./tools/bin/go-winres simply --file-version $(VERSION) --product-name "Red Hat OpenShift Local Background Launcher"
-	GOOS=windows go build -ldflags -H=windowsgui -o bin/crc-background-launcher.exe ./
+	GOOS=windows go build -ldflags -H=windowsgui -o bin/win32-background-launcher.exe ./
 	
 .PHONY: vendor
 vendor: vendor-tools

--- a/win32-background-launcher.spec
+++ b/win32-background-launcher.spec
@@ -46,10 +46,10 @@ make
 %install
 # with fedora macros: gopkginstall
 install -m 0755 -vd %{buildroot}%{_bindir}
-install -m 0755 -vp %{gobuilddir}/src/%{goipath}/bin/crc-background-launcher.exe %{buildroot}%{_bindir}/
+install -m 0755 -vp %{gobuilddir}/src/%{goipath}/bin/win32-background-launcher.exe %{buildroot}%{_bindir}/
 
 install -d %{buildroot}%{_datadir}/%{name}-redistributable/windows
-install -m 0755 -vp %{gobuilddir}/src/%{goipath}/bin/crc-background-launcher.exe %{buildroot}%{_datadir}/%{name}-redistributable/windows/
+install -m 0755 -vp %{gobuilddir}/src/%{goipath}/bin/win32-background-launcher.exe %{buildroot}%{_datadir}/%{name}-redistributable/windows/
 
 %files
 %license %{golicenses}


### PR DESCRIPTION
This reverts commit 1668a1b27800e4085ae23ba6254424386cf4ab0c.

the executable will be renamed to crc-background-luancher.exe in the crc codebase, since the tool does nothing crc specific we keep the earlier name win32-background-launcher.exe