### PR TITLE
fix out of bounds index in binaryAndArgs

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,9 +11,9 @@ func binaryAndArgs() (string, []string) {
 	// os.Args[1] is the name of the binary we want to start in the background
 	// os.Args[2:] are the arguments of our binary
 	switch {
-	case len(os.Args) == 0:
+	case len(os.Args) <= 1:
 		return "", []string{}
-	case len(os.Args) == 1:
+	case len(os.Args) == 2:
 		return os.Args[1], []string{}
 	default:
 		return os.Args[1], os.Args[2:]


### PR DESCRIPTION
The function was accessing os.Args[1] when len(os.Args) == 1, causing a unhandle panic. Now properly handles edge cases by checking for <= 1 args before accessing the index.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line argument parsing to correctly handle edge cases with minimal input parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->