### PR TITLE
Fix setting of Cmd.Stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ func main() {
 	cmd := exec.Command(binaryPath, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: 0x08000000}
 	cmd.Stdout = os.Stdout
-	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
 	err := cmd.Run()
 	if err != nil {
 		panic(err.Error())


### PR DESCRIPTION
Cmd.Stdout was set twice, and Cmd.Stderr was never set, this is most likely a copy and paste error.

This commit should fix this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed incorrect routing of child process output and error streams, ensuring output is properly displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->